### PR TITLE
Allow auth explicit configuration in task options.

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,17 @@ Username and password are stored as a JSON object in a file named `.ftppass`, Th
 }
 ```
 
+It is also possible to explicitly set username and password in task options:
+
+```js
+{
+  options: {
+    // WARNING: Never commit this kind of explicit configuration into source control !!
+    username: 'username1',
+    password: 'password1'
+  }
+}
+```
 
 ### Options
 
@@ -87,6 +98,12 @@ Type: `String`
 Default value: `same as options.host`
 
 Key in the `.ftppass`.
+
+### options.auth
+Type: `Object`
+Default value: `undefined`
+
+Explicit auth configuration, an object with username and password keys.
 
 #### options.passive
 Type: `Boolean`

--- a/tasks/ftpscript.coffee
+++ b/tasks/ftpscript.coffee
@@ -13,10 +13,11 @@ module.exports = exports = (grunt)->
       ftpEncoding: 'utf-8'
       mkdirs: on
 
-    auth = grunt.file.readJSON('.ftppass')?[opts.authKey ? opts.host]
+    auth = opts.auth or grunt.file.readJSON('.ftppass')?[opts.authKey ? opts.host]
 
     if not auth or not auth.username
-      grunt.fatal "Not found \"#{ opts.authKey }\" or \"#{ opts.host }\" in file .ftppass"
+      grunt.fatal "Not found \"#{ opts.authKey }\" or \"#{ opts.host }\" in file .ftppass,
+                   and no explicit auth configuration was found in task options"
       return no
 
     cmds = [
@@ -31,7 +32,7 @@ module.exports = exports = (grunt)->
     files = []
 
     generateUpload dirs, files, f for f in @files
-      
+
     if opts.mkdirs
       dirs = for i of dirs
         "mkdir \"#{ i }\""
@@ -46,7 +47,7 @@ module.exports = exports = (grunt)->
         f = if t is last then f else "type #{ t }\n#{ f }"
         last = t
         f
-          
+
 
     for arg in args
       switch arg


### PR DESCRIPTION
I know this could lead to a security risk if committed into source control. That's why I've added to the documentation a warning about it.

The reason I needed this is because I have some other sensitive information I don't want to put into source control, and I didn't want to have 2 separate files (.ftppass and my other file). Now I can put all my auth configs in one file, and then pass the ftp user/pass via the task options.
